### PR TITLE
fix($node): removed top level reference to document in module

### DIFF
--- a/packages/svg-baker-runtime/src/utils/parse.js
+++ b/packages/svg-baker-runtime/src/utils/parse.js
@@ -1,10 +1,9 @@
-const hasImportNode = !!document.importNode;
-
 /**
  * @param {string} content
  * @return {Element}
  */
 export default function (content) {
+  const hasImportNode = !!document.importNode;
   const doc = new DOMParser().parseFromString(content, 'image/svg+xml').documentElement;
 
   /**


### PR DESCRIPTION
Summary: This makes it easier to extend the default sprite and symbol modules in svg-sprite-loader if you want to create modules that will produce a webpack bundle that can run isomorphically.

Motivation: We created a react component library and used svg-sprite-loader in our webpack build to bundle the components together with their dependencies. There was a desire to import these bundled components into an larger React application that could be rendered isomorphically. To accomplish this, we needed a way to not have our application throw errors when it renders server side and there are no references to the DOM apis. 

Our plan was to implement custom sprite and symbol modules, as is suggested in the svg-sprite-loader README. The initial plan as to import and extend the BrowserSpriteSymbol and BrowserSprite classes from svg-baker-runtime, and override methods that used the DOM apis. 

Essentially do something like this:
```
MyCustomSymbolModule extends BrowserSpriteSymbol {
  mount() {
    try {
      super.mount();
    } catch(e) { }
  }
}
```
For our purposes, we didn't really care if these methods failed silently server side. 

The problem we ran into was that when we bundled our component library using these modules and tried to import it in the Node environment when our other application ran, we would get errors saying "document" was undefined because of the top level reference in the parse module.

Moving "document" into a function, means we can try/catch code that references DOM apis 