### PR TITLE
fix(runtime): fix IE/Edge rendering with SVG containing 'style' elements

### DIFF
--- a/packages/svg-baker-runtime/src/browser-symbol.js
+++ b/packages/svg-baker-runtime/src/browser-symbol.js
@@ -38,6 +38,18 @@ export default class BrowserSpriteSymbol extends SpriteSymbol {
       moveGradientsOutsideSymbol(mountTarget);
     }
 
+    // :WORKAROUND:
+    // IE doesn't evaluate <style> tags in SVGs that are dynamically added to the page.
+    // This trick will trigger IE to read and use any existing SVG <style> tags.
+    //
+    // Reference: https://github.com/iconic/SVGInjector/issues/23
+    if (browser.isIE || browser.isEdge) {
+      const styles = document.querySelectorAll('style');
+      for (let i = 0, l = styles.length; i < l; i += 1) {
+        styles[i].textContent += '';
+      }
+    }
+
     return node;
   }
 

--- a/packages/svg-baker-runtime/src/utils/browser-detector.js
+++ b/packages/svg-baker-runtime/src/utils/browser-detector.js
@@ -3,6 +3,8 @@ const ua = navigator.userAgent;
 export default {
   isChrome: /chrome/i.test(ua),
   isFirefox: /firefox/i.test(ua),
-  isIE: /msie/i.test(ua),
+
+  // https://msdn.microsoft.com/en-us/library/ms537503(v=vs.85).aspx
+  isIE: /msie/i.test(ua) || /trident/i.test(ua),
   isEdge: /edge/i.test(ua)
 };


### PR DESCRIPTION
This workaround forces IE to evaluate the <style /> elements of the dynamically loaded symbols.
