### PR TITLE
Do not encode "(", ")" and "~" symbols

### DIFF
--- a/packages/svg-baker-runtime/src/utils/update-urls.js
+++ b/packages/svg-baker-runtime/src/utils/update-urls.js
@@ -6,7 +6,7 @@ const xLinkNS = namespaces.xlink.uri;
 const xLinkAttrName = 'xlink:href';
 
 // eslint-disable-next-line no-useless-escape
-const specialUrlCharsPattern = /[(){}|\\\^~\[\]`"<>]/g;
+const specialUrlCharsPattern = /[{}|\\\^\[\]`"<>]/g;
 
 function encoder(url) {
   return url.replace(specialUrlCharsPattern, (match) => {


### PR DESCRIPTION
Since these symbols are pure symbols in the URL they should not be encoded.